### PR TITLE
Fix TypeError: cannot unpack non-iterable CommandHandler object

### DIFF
--- a/mauhelp.py
+++ b/mauhelp.py
@@ -7,7 +7,7 @@ class MauHelp(Plugin):
     @command.new(name="help", help="Shows this help text")
     async def help(self, evt: MessageEvent):
         help_text_dict = {}
-        for handler_func, _ in self.client.event_handlers[EventType.ROOM_MESSAGE]:
+        for handler_func in self.client.event_handlers[EventType.ROOM_MESSAGE]:
             command_help = ""
             if hasattr(handler_func, "__mb_name__") and hasattr(handler_func, "__mb_usage_inline__"):
                 # Initialize the key if it doesn't exist


### PR DESCRIPTION
Hello! I found that in the latest version of Maubot/mautrix-python, self.client.event_handlers returns a CommandHandler object directly rather than a tuple. This causes the plugin to crash when trying to unpack it.

I've updated the loop in mauhelp.py to fix this issue. Tested and working on Maubot v0.4.x.